### PR TITLE
Fix MIME Type For MKV

### DIFF
--- a/server/Types/DlnaMaps.cs
+++ b/server/Types/DlnaMaps.cs
@@ -101,7 +101,7 @@ namespace NMaier.SimpleDlna.Server
       {DlnaMime.VideoAVC, "video/mp4"},
       {DlnaMime.VideoAVI, "video/avi"},
       {DlnaMime.VideoFLV, "video/flv"},
-      {DlnaMime.VideoMKV, "video/x-mkv"},
+      {DlnaMime.VideoMKV, "video/x-matroska"},
       {DlnaMime.VideoMPEG, "video/mpeg"},
       {DlnaMime.VideoOGV, "video/ogg"},
       {DlnaMime.VideoWMV, "video/x-ms-wmv"}


### PR DESCRIPTION
- The correct MIME type for MKV files is "video/x-matroska" as per
https://matroska.org/technical/specs/notes.html .